### PR TITLE
Fix for media manager image crop popup styles

### DIFF
--- a/assets/css/src/custom.css
+++ b/assets/css/src/custom.css
@@ -164,3 +164,19 @@ div[id^='headlessui-menu-items-'] {
 .loading-indicator ~ .btn-text {
     @apply hidden;
 }
+
+[data-control=toolbar] {
+    label {
+        display: inline-block;
+    }
+
+    .select2-container {
+        width: auto !important;
+    }
+
+    input {
+        min-width: 4em;
+        padding: 6px !important;
+        text-align: right;
+    }
+}


### PR DESCRIPTION
Before
<img width="1191" alt="Screen Shot 2022-08-22 at 1 38 30 PM" src="https://user-images.githubusercontent.com/7253840/186004769-9f310ce0-76a9-4819-8015-d91c7c7e728d.png">

After
<img width="1200" alt="Screen Shot 2022-08-22 at 1 39 05 PM" src="https://user-images.githubusercontent.com/7253840/186004789-3e4415ff-08a5-494f-b782-7f4fd8c54519.png">

