### PR TITLE
Reworks brand's colors palette

### DIFF
--- a/skins/tailwindui/layouts/_branding.php
+++ b/skins/tailwindui/layouts/_branding.php
@@ -9,13 +9,14 @@ $secondary = BrandSetting::get('secondary_color', BrandSetting::SECONDARY_COLOR)
 $getVariations = function ($colorString) {
     return Cache::remember("backend.brand.color.variations.{$colorString}", now()->addMonths(1), function () use ($colorString) {
         $color = new Color($colorString);
+        $luminance = $color->getHsl()['L'] * 100;
         return [
-            'dark' => $color->darken(0.20),
-            'darker' => $color->darken(0.30),
-            'darkest' => $color->darken(0.40),
-            'light' => $color->lighten(0.25),
-            'lighter' => $color->lighten(0.30),
-            'lightest' => $color->lighten(0.35),
+            'dark' => $color->darken(($luminance / 4)),
+            'darker' => $color->darken(($luminance / 4) * 2),
+            'darkest' => $color->darken(($luminance / 4) * 3),
+            'light' => $color->lighten((100 - $luminance) / 4),
+            'lighter' => $color->lighten((100 - $luminance) / 4 * 2),
+            'lightest' => $color->lighten((100 - $luminance) / 4 * 3),
         ];
     });
 };


### PR DESCRIPTION
Redesign of the brand's color palette while waiting for a better way to do it with a library.
Fix #14 

The three darker or lighter shades are evenly distributed over the luminance channel.

**Before :**  
![image](https://user-images.githubusercontent.com/282242/189019960-47b4a97c-7be6-453a-a514-fb5010515142.png)

**After :**  
![image](https://user-images.githubusercontent.com/282242/189023176-c74b759b-20b4-4796-87ab-24d5688559a3.png)
