### PR TITLE
Change default theme to light

### DIFF
--- a/models/preference/fields.yaml
+++ b/models/preference/fields.yaml
@@ -4,7 +4,7 @@ tabs:
             label: 'winter.tailwindui::lang.preferences.appearance'
             type: 'dropdown'
             tab: 'winter.tailwindui::lang.preferences.appearance'
-            default: auto
+            default: light
             permissions: winter.tailwindui.manage_own_appearance.dark_mode
             options:
                 auto: ['winter.tailwindui::lang.preferences.dark_mode.auto', 'icon-computer']

--- a/skins/tailwindui/layouts/auth-simple.php
+++ b/skins/tailwindui/layouts/auth-simple.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<?= App::getLocale() ?>" class="no-js h-full bg-gray-50" data-color-scheme="<?= e(\Backend\Models\Preference::instance()->get('dark_mode', 'auto')); ?>">
+<html lang="<?= App::getLocale() ?>" class="no-js h-full bg-gray-50" data-color-scheme="<?= e(\Backend\Models\Preference::instance()->get('dark_mode', 'light')); ?>">
     <head>
         <?= $this->makeLayoutPartial('head_auth') ?>
         <?= $this->fireViewEvent('backend.layout.extendHead', ['layout' => 'auth']) ?>

--- a/skins/tailwindui/layouts/auth-split.php
+++ b/skins/tailwindui/layouts/auth-split.php
@@ -7,7 +7,7 @@
         $backgroundImage = $brandSettings->background_image->path;
     }
 ?>
-<html lang="<?= App::getLocale() ?>" class="no-js" data-color-scheme="<?= e(\Backend\Models\Preference::instance()->get('dark_mode', 'auto')); ?>">
+<html lang="<?= App::getLocale() ?>" class="no-js" data-color-scheme="<?= e(\Backend\Models\Preference::instance()->get('dark_mode', 'light')); ?>">
     <head>
         <?= $this->makeLayoutPartial('head_auth') ?>
         <?= $this->fireViewEvent('backend.layout.extendHead', ['layout' => 'auth']) ?>

--- a/skins/tailwindui/layouts/default.php
+++ b/skins/tailwindui/layouts/default.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<?= App::getLocale() ?>" class="no-js <?= $this->makeLayoutPartial('browser_detector') ?>" data-color-scheme="<?= e(\Backend\Models\Preference::instance()->get('dark_mode', 'auto')); ?>">
+<html lang="<?= App::getLocale() ?>" class="no-js <?= $this->makeLayoutPartial('browser_detector') ?>" data-color-scheme="<?= e(\Backend\Models\Preference::instance()->get('dark_mode', 'light')); ?>">
     <head>
         <?= $this->makeLayoutPartial('head') ?>
         <?= $this->fireViewEvent('backend.layout.extendHead', ['layout' => 'default']) ?>


### PR DESCRIPTION
In a recent PR the dark mode has been introduced with 3 available options: auto (system), light and dark.

However, to preserve brand standards, but also remain aligned to how any other web apps out there do it, the default should always start from light.

This would also ensure that anyone that was already using tailwindui, and made custom extensions to it, does not get "slapped" with "auto" (and the system is set to dark) and end up having a theme that looks more like a dalmatian than a dark mode theme - cause obviously previous users never accommodated for dark mode being introduced.