### PR TITLE
makes head template compatible with backend v1.2.1

### DIFF
--- a/skins/tailwindui/layouts/_head.php
+++ b/skins/tailwindui/layouts/_head.php
@@ -28,13 +28,7 @@ $scripts = [
     Url::asset('modules/system/assets/js/framework.js'),
     Url::asset('modules/system/assets/js/build/manifest.js'),
     Url::asset('modules/system/assets/js/snowboard/build/snowboard.vendor.js'),
-    Url::asset(
-        (Config::get('develop.debugSnowboard', Config::get('app.debug', false)) === true)
-            ? 'modules/system/assets/js/build/system.debug.js'
-            : 'modules/system/assets/js/build/system.js'
-    ),
-    Url::asset('modules/backend/assets/ui/js/build/manifest.js'),
-    Url::asset('modules/backend/assets/ui/js/build/vendor.js'),
+    Url::asset('modules/system/assets/js/build/system.js'),
     Url::asset('modules/backend/assets/ui/js/build/backend.js'),
 ];
 if (Config::get('develop.decompileBackendAssets', false)) {


### PR DESCRIPTION
This PR restores compatibility of the tailwind ui plugin with the v1.2.1 release of the winter backend module.