### PR TITLE
Fixed the logic for logo image

### DIFF
--- a/skins/tailwindui/layouts/_menu-side.php
+++ b/skins/tailwindui/layouts/_menu-side.php
@@ -31,7 +31,7 @@
                 <div class="flex items-center mb-4 h-16 shrink-0">
                     <img
                         class="h-12 w-auto <?= $itemMode === 'tile' ? 'm-auto' : '' ?>"
-                        src="<?= e($logoImage) ?? Url::asset('modules/backend/assets/images/winter-logo-white.svg') ?>"
+                        src="<?= e($logoImage) ?: Url::asset('modules/backend/assets/images/winter-logo-white.svg') ?>"
                         alt="<?= $appName ?>"
                     >
                 </div>


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->
## Bug
Winter logo isn't displayed.

<img width="864" height="336" alt="Screenshot from 2025-07-23 15-11-21" src="https://github.com/user-attachments/assets/35fb68cd-d872-4425-a487-93abb06bad28" />


## Updates
e($logoImage) returns an empty string when the value is null, so `??` doesn't trigger the fallback. I replaced it with `?:` 

